### PR TITLE
re-enable symfony 2.3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,6 +15,8 @@ php:
 matrix:
   include:
     - php: 5.6
+      env: SYMFONY_VERSION="2.3.*"
+    - php: 5.6
       env: SYMFONY_VERSION="2.7.*"
     - php: 5.6
       env: SYMFONY_VERSION="2.8.*"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
+Version 1.2.0
+=============
+- Re-Enable Symfony 2.3 - use v2.0 for Symfony 3.0 compatible version
+
 Version 1.1.0
-=====================
+=============
 
 - Fix for loading additional toggles with extensions (@benniezwerver)
 - Implementing TravisCI 

--- a/Resources/config/services.yml
+++ b/Resources/config/services.yml
@@ -27,7 +27,7 @@ services:
 
     dz.feature_flags.toggle.condition.percentage:
         class: DZunke\FeatureFlagsBundle\Toggle\Conditions\Percentage
-        arguments: ["@request_stack"]
+        arguments: ["@request"]
         calls:
             - [setContext, ["@dz.feature_flags.context"]]
         tags:
@@ -35,7 +35,7 @@ services:
 
     dz.feature_flags.toggle.condition.device:
             class: DZunke\FeatureFlagsBundle\Toggle\Conditions\Device
-            arguments: ["@request_stack"]
+            arguments: ["@request"]
             calls:
                 - [setContext, ["@dz.feature_flags.context"]]
             tags:

--- a/Tests/Toggle/Conditions/DeviceTest.php
+++ b/Tests/Toggle/Conditions/DeviceTest.php
@@ -8,25 +8,24 @@ use DZunke\FeatureFlagsBundle\Toggle\Conditions\Device;
 use PHPUnit_Framework_TestCase;
 use Symfony\Component\HttpFoundation\HeaderBag;
 use Symfony\Component\HttpFoundation\Request;
-use Symfony\Component\HttpFoundation\RequestStack;
 use PHPUnit_Framework_MockObject_MockObject;
 
 class DeviceTest extends PHPUnit_Framework_TestCase
 {
 
     /**
-     * @var RequestStack|PHPUnit_Framework_MockObject_MockObject
+     * @var Request|PHPUnit_Framework_MockObject_MockObject
      */
-    private $requestStackMock;
+    private $request;
 
     public function setUp()
     {
-        $this->requestStackMock = $this->getMock(RequestStack::class);
+        $this->request = $this->getMock(Request::class);
     }
 
     public function testItExtendsCorrectly()
     {
-        $sut = new Device($this->requestStackMock);
+        $sut = new Device($this->request);
 
         $this->assertInstanceOf(AbstractCondition::class, $sut);
         $this->assertInstanceOf(ConditionInterface::class, $sut);
@@ -34,7 +33,7 @@ class DeviceTest extends PHPUnit_Framework_TestCase
 
     public function testIsReturnsFalseItConfigIsIncorrect()
     {
-        $sut = new Device($this->requestStackMock);
+        $sut = new Device($this->request);
 
         $this->assertFalse($sut->validate(null));
     }
@@ -47,9 +46,7 @@ class DeviceTest extends PHPUnit_Framework_TestCase
         $requestMock = $this->getMock(Request::class);
         $requestMock->headers = $headerBagMock;
 
-        $this->requestStackMock->method('getMasterRequest')->willReturn($requestMock);
-
-        $sut = new Device($this->requestStackMock);
+        $sut = new Device($requestMock);
 
         $this->assertFalse($sut->validate([], null));
     }
@@ -62,9 +59,7 @@ class DeviceTest extends PHPUnit_Framework_TestCase
         $requestMock = $this->getMock(Request::class);
         $requestMock->headers = $headerBagMock;
 
-        $this->requestStackMock->method('getMasterRequest')->willReturn($requestMock);
-
-        $sut = new Device($this->requestStackMock);
+        $sut = new Device($requestMock);
 
         $array = [
             'first-agents' => '/^Custom-Agent-1|Custom-Agent-2|Custom-Agent-3|Custom-Agent-4$/',
@@ -83,9 +78,7 @@ class DeviceTest extends PHPUnit_Framework_TestCase
         $requestMock = $this->getMock(Request::class);
         $requestMock->headers = $headerBagMock;
 
-        $this->requestStackMock->method('getMasterRequest')->willReturn($requestMock);
-
-        $sut = new Device($this->requestStackMock);
+        $sut = new Device($requestMock);
 
         $array = [
             'first-agents' => '/^Custom-Agent-1|Custom-Agent-2|Custom-Agent-3|Custom-Agent-4$/',
@@ -98,7 +91,7 @@ class DeviceTest extends PHPUnit_Framework_TestCase
 
     public function testToString()
     {
-        $sut = new Device($this->requestStackMock);
+        $sut = new Device($this->request);
 
         $this->assertSame('device', (string) $sut);
     }

--- a/Tests/Toggle/Conditions/PercentageTest.php
+++ b/Tests/Toggle/Conditions/PercentageTest.php
@@ -9,16 +9,15 @@ use Exception;
 use PHPUnit_Framework_TestCase;
 use Symfony\Component\DependencyInjection\ParameterBag\ParameterBag;
 use Symfony\Component\HttpFoundation\Request;
-use Symfony\Component\HttpFoundation\RequestStack;
 
 class PercentageTest extends PHPUnit_Framework_TestCase
 {
 
     public function testItExtendsCorrectly()
     {
-        $requestStackMock = $this->getMock(RequestStack::class);
+        $request = $this->getMock(Request::class);
 
-        $sut = new Percentage($requestStackMock);
+        $sut = new Percentage($request);
 
         $this->assertInstanceOf(AbstractCondition::class, $sut);
         $this->assertInstanceOf(ConditionInterface::class, $sut);
@@ -28,9 +27,9 @@ class PercentageTest extends PHPUnit_Framework_TestCase
     {
         $this->setExpectedException(Exception::class);
 
-        $requestStackMock = $this->getMock(RequestStack::class);
+        $request = $this->getMock(Request::class);
 
-        $sut = new Percentage($requestStackMock);
+        $sut = new Percentage($request);
         $sut->validate([], 'nothing');
     }
 
@@ -43,10 +42,7 @@ class PercentageTest extends PHPUnit_Framework_TestCase
         $requestMock = $this->getMock(Request::class);
         $requestMock->cookies = $parameterBagMock;
 
-        $requestStackMock = $this->getMock(RequestStack::class);
-        $requestStackMock->method('getMasterRequest')->willReturn($requestMock);
-
-        $sut = new Percentage($requestStackMock);
+        $sut = new Percentage($requestMock);
         $this->assertTrue($sut->validate([
             'percentage' => 798,
         ]));
@@ -60,18 +56,13 @@ class PercentageTest extends PHPUnit_Framework_TestCase
         $requestMock = $this->getMock(Request::class);
         $requestMock->cookies = $parameterBagMock;
 
-        $requestStackMock = $this->getMock(RequestStack::class);
-        $requestStackMock->method('getMasterRequest')->willReturn($requestMock);
-
-        $sut = new Percentage($requestStackMock);
+        $sut = new Percentage($requestMock);
         $this->assertInternalType('bool', $sut->validate(['percentage' => 3]));
     }
 
     public function testToString()
     {
-        $requestStackMock = $this->getMock(RequestStack::class);
-
-        $sut = new Percentage($requestStackMock);
+        $sut = new Percentage($this->getMock(Request::class));
 
         $this->assertSame('percentage', (string) $sut);
     }

--- a/Toggle/Conditions/Device.php
+++ b/Toggle/Conditions/Device.php
@@ -3,7 +3,6 @@
 namespace DZunke\FeatureFlagsBundle\Toggle\Conditions;
 
 use Symfony\Component\HttpFoundation\Request;
-use Symfony\Component\HttpFoundation\RequestStack;
 
 class Device extends AbstractCondition implements ConditionInterface
 {
@@ -14,11 +13,11 @@ class Device extends AbstractCondition implements ConditionInterface
     private $request;
 
     /**
-     * @param RequestStack $request
+     * @param Request $request
      */
-    public function __construct(RequestStack $request)
+    public function __construct(Request $request)
     {
-        $this->request = $request->getMasterRequest();
+        $this->request = $request;
     }
 
     /**

--- a/Toggle/Conditions/Percentage.php
+++ b/Toggle/Conditions/Percentage.php
@@ -3,7 +3,6 @@
 namespace DZunke\FeatureFlagsBundle\Toggle\Conditions;
 
 use Symfony\Component\HttpFoundation\Request;
-use Symfony\Component\HttpFoundation\RequestStack;
 
 class Percentage extends AbstractCondition implements ConditionInterface
 {
@@ -20,11 +19,11 @@ class Percentage extends AbstractCondition implements ConditionInterface
     private $request;
 
     /**
-     * @param RequestStack $request
+     * @param Request $request
      */
-    public function __construct(RequestStack $request)
+    public function __construct(Request $request)
     {
-        $this->request = $request->getMasterRequest();
+        $this->request = $request;
     }
 
     /**

--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
     ],
     "require": {
         "php": ">=5.5",
-        "symfony/symfony": "~2.7|~3.0"
+        "symfony/symfony": "~2.3|~3.0"
     },
     "require-dev": {
         "phpunit/phpunit": "~4"


### PR DESCRIPTION
Due to Issue #4 it was a mistake to remove symfony 2.3 support in the 1.x-branch, so this will revert this change and re-enable symfony 2.3 support. 
