### PR TITLE
Only require used dependencies

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -5,6 +5,7 @@
     "homepage": "https://github.com/DZunke/FeatureFlagsBundle",
     "license": "MIT",
     "minimum-stability": "dev",
+    "prefer-stable": true,
     "authors": [
         {
             "name": "Denis Zunke",
@@ -13,7 +14,13 @@
     ],
     "require": {
         "php": ">=5.5",
-        "symfony/symfony": "~2.3"
+        "symfony/http-foundation": "~2.3",
+        "symfony/http-kernel": "~2.3",
+        "symfony/dependency-injection": "~2.3",
+        "symfony/config": "~2.3",
+        "symfony/console": "~2.3",
+        "symfony/framework-bundle": "~2.3",
+        "symfony/twig-bridge": "~2.3"
     },
     "require-dev": {
         "phpunit/phpunit": "~4"


### PR DESCRIPTION
I refactored the `composer.json` for requiring some Symfony components rather than all components in Symfony. The requirements in `.travis.yml` should also be checked.