### PR TITLE
Requirement changed from symfony/symfony to symfony/framework-bundle

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,10 +13,11 @@
     ],
     "require": {
         "php": ">=5.5",
-        "symfony/symfony": "~2.7|~3.0"
+        "symfony/framework-bundle": "~2.7|~3.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "~4"
+        "phpunit/phpunit": "~4",
+        "twig/twig": "~2"
     },
     "autoload": {
         "psr-0": { "DZunke\\FeatureFlagsBundle": "" }


### PR DESCRIPTION
…and added Twig as dev-dependency.

This PR resolves a conflict when using this bundle with symfony-flex, because symfony/flex conflicts with package symfony/symfony which is not really required by this bundle. 