### PR TITLE
Inject request stack using @request_stack

### DIFF
--- a/Resources/config/services.yml
+++ b/Resources/config/services.yml
@@ -32,7 +32,7 @@ services:
 
     dz.feature_flags.toggle.condition.percentage:
         class: DZunke\FeatureFlagsBundle\Toggle\Conditions\Percentage
-        arguments: ["@request"]
+        arguments: ["@request_stack"]
         calls:
             - [setContext, ["@dz.feature_flags.context"]]
         tags:
@@ -40,7 +40,7 @@ services:
 
     dz.feature_flags.toggle.condition.device:
             class: DZunke\FeatureFlagsBundle\Toggle\Conditions\Device
-            arguments: ["@request"]
+            arguments: ["@request_stack"]
             calls:
                 - [setContext, ["@dz.feature_flags.context"]]
             tags:


### PR DESCRIPTION
Instead of using `@request` which no longer appears to exist in Symfony, inject the request stack correctly using `@request_stack` which has been available since Symfony 2.4.