### PR TITLE
Symfony 5.1 support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+Version 5.0
+===========
+* Support up to Symfony 5.1
+
 Version 4.2
 ===========
 * Fix Deprecation of Request-Injection in Service Definition (thanks @benr77)

--- a/EventListener/ContextCreator.php
+++ b/EventListener/ContextCreator.php
@@ -3,7 +3,7 @@
 namespace DZunke\FeatureFlagsBundle\EventListener;
 
 use DZunke\FeatureFlagsBundle\Context;
-use Symfony\Component\HttpKernel\Event\GetResponseEvent;
+use Symfony\Component\HttpKernel\Event\RequestEvent;
 
 class ContextCreator
 {
@@ -21,9 +21,9 @@ class ContextCreator
     }
 
     /**
-     * @param GetResponseEvent $event
+     * @param RequestEvent $event
      */
-    public function onKernelRequest(GetResponseEvent $event)
+    public function onKernelRequest(RequestEvent $event)
     {
         $this->context->set('client_ip', $event->getRequest()->getClientIp());
         $this->context->set('hostname', $event->getRequest()->getHost());

--- a/README.md
+++ b/README.md
@@ -6,7 +6,9 @@ The Bundle will allow you to implement Feature Flags to your Application.
 Please Note that there is no Interface available, so the Flags must be
 configured directly in Symfony-Configs.
 
-**Use Versions >= 2.0 if Symfony 3.0 Support is wanted!**
+**Use Versions ^2.0 if Symfony 3.0 Support is wanted!**
+**Use Versions ^4.0 if Symfony 4.2 Support is wanted!**
+**Use Versions ^5.0 if Symfony 4.3 or 5.x Support is wanted!**
 
 ## Documentation
 
@@ -15,12 +17,12 @@ configured directly in Symfony-Configs.
 You can add the Bundle by running [Composer](http://getcomposer.org) on your shell or adding it directly to your composer.json
 
 ``` bash
-php composer.phar require dzunke/feature-flags-bundle:dev-master
+php composer.phar require dzunke/feature-flags-bundle:"^5.0"
 ```
 
 ``` json
 "require" :  {
-    "dzunke/feature-flags-bundle": "dev-master"
+    "dzunke/feature-flags-bundle": "^5.0"
 }
 ```
 The Namespace will be registered by autoloading with Composer but to use the integrated features for symfony you have to register the Bundle.

--- a/composer.json
+++ b/composer.json
@@ -13,13 +13,13 @@
     ],
     "require": {
         "php": ">=7.2",
-        "symfony/http-foundation": "~4.0|~5.0",
-        "symfony/http-kernel": "~4.0|~5.0",
-        "symfony/dependency-injection": "~4.0|~5.0",
-        "symfony/config": "~4.0|~5.0",
-        "symfony/console": "~4.0|~5.0",
-        "symfony/twig-bridge": "~4.0|~5.0",
-        "symfony/yaml": "~4.0|~5.0"
+        "symfony/http-foundation": "~4.3|~5.0",
+        "symfony/http-kernel": "~4.3|~5.0",
+        "symfony/dependency-injection": "~4.3|~5.0",
+        "symfony/config": "~4.3|~5.0",
+        "symfony/console": "~4.3|~5.0",
+        "symfony/twig-bridge": "~4.3|~5.0",
+        "symfony/yaml": "~4.3|~5.0"
     },
     "require-dev": {
         "twig/twig": "~2.0|~3.0",


### PR DESCRIPTION
To get this bundle working with Symfony 5.1, I've fixed the usage of the deprecated `GetResponseEvent` class and replaced with `RequestEvent`.

This is a breaking change, so once this PR is merged, **please tag a new release 5.0.**

I have updated the README and the CHANGELOG so that it's clear what versions to use for different versions of Symfony.