### PR TITLE
Fix type in namespace to make PSR compliant

### DIFF
--- a/Tests/Toggle/Conditions/DateTest.php
+++ b/Tests/Toggle/Conditions/DateTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace DZunke\FeatureFlagsBundle\Tests\Toggle\Condition;
+namespace DZunke\FeatureFlagsBundle\Tests\Toggle\Conditions;
 
 use DZunke\FeatureFlagsBundle\Context;
 use DZunke\FeatureFlagsBundle\Toggle\Conditions\AbstractCondition;

--- a/Tests/Toggle/Conditions/DeviceTest.php
+++ b/Tests/Toggle/Conditions/DeviceTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace DZunke\FeatureFlagsBundle\Tests\Toggle\Condition;
+namespace DZunke\FeatureFlagsBundle\Tests\Toggle\Conditions;
 
 use DZunke\FeatureFlagsBundle\Toggle\Conditions\AbstractCondition;
 use DZunke\FeatureFlagsBundle\Toggle\Conditions\ConditionInterface;

--- a/Tests/Toggle/Conditions/HostnameTest.php
+++ b/Tests/Toggle/Conditions/HostnameTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace DZunke\FeatureFlagsBundle\Tests\Toggle\Condition;
+namespace DZunke\FeatureFlagsBundle\Tests\Toggle\Conditions;
 
 use DZunke\FeatureFlagsBundle\Context;
 use DZunke\FeatureFlagsBundle\Toggle\Conditions\AbstractCondition;

--- a/Tests/Toggle/Conditions/IpAddressTest.php
+++ b/Tests/Toggle/Conditions/IpAddressTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace DZunke\FeatureFlagsBundle\Tests\Toggle\Condition;
+namespace DZunke\FeatureFlagsBundle\Tests\Toggle\Conditions;
 
 use DZunke\FeatureFlagsBundle\Context;
 use DZunke\FeatureFlagsBundle\Toggle\Conditions\AbstractCondition;

--- a/Tests/Toggle/Conditions/PercentageTest.php
+++ b/Tests/Toggle/Conditions/PercentageTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace DZunke\FeatureFlagsBundle\Tests\Toggle\Condition;
+namespace DZunke\FeatureFlagsBundle\Tests\Toggle\Conditions;
 
 use DZunke\FeatureFlagsBundle\Toggle\Conditions\AbstractCondition;
 use DZunke\FeatureFlagsBundle\Toggle\Conditions\ConditionInterface;


### PR DESCRIPTION
The `Condition` namespace in the tests directory should be called `Conditions` (plural), and Composer 2.0 is complaining about this. 

This PR simply fixes the namespace to match the folder name, which also aligns with the name used in the `src/` directory.