### PR TITLE
Stop deprecation notice for Symfony versions > 5.3

### DIFF
--- a/Tests/Toggle/Conditions/DeviceTest.php
+++ b/Tests/Toggle/Conditions/DeviceTest.php
@@ -12,7 +12,6 @@ use Symfony\Component\HttpFoundation\RequestStack;
 
 class DeviceTest extends TestCase
 {
-
     /**
      * @var RequestStack
      */
@@ -46,7 +45,7 @@ class DeviceTest extends TestCase
         $requestMock = $this->createMock(Request::class);
         $requestMock->headers = $headerBagMock;
 
-        $this->requestStackMock->method('getMasterRequest')->willReturn($requestMock);
+        $this->requestStackMock->method('getMainRequest')->willReturn($requestMock);
 
         $sut = new Device($this->requestStackMock);
 
@@ -61,7 +60,7 @@ class DeviceTest extends TestCase
         $requestMock = $this->createMock(Request::class);
         $requestMock->headers = $headerBagMock;
 
-        $this->requestStackMock->method('getMasterRequest')->willReturn($requestMock);
+        $this->requestStackMock->method('getMainRequest')->willReturn($requestMock);
 
         $sut = new Device($this->requestStackMock);
 
@@ -82,7 +81,7 @@ class DeviceTest extends TestCase
         $requestMock = $this->createMock(Request::class);
         $requestMock->headers = $headerBagMock;
 
-        $this->requestStackMock->method('getMasterRequest')->willReturn($requestMock);
+        $this->requestStackMock->method('getMainRequest')->willReturn($requestMock);
 
         $sut = new Device($this->requestStackMock);
 

--- a/Tests/Toggle/Conditions/PercentageTest.php
+++ b/Tests/Toggle/Conditions/PercentageTest.php
@@ -44,7 +44,7 @@ class PercentageTest extends TestCase
         $requestMock->cookies = $parameterBagMock;
 
         $requestStackMock = $this->createMock(RequestStack::class);
-        $requestStackMock->method('getMasterRequest')->willReturn($requestMock);
+        $requestStackMock->method('getMainRequest')->willReturn($requestMock);
 
         $sut = new Percentage($requestStackMock);
         $this->assertTrue($sut->validate([
@@ -61,7 +61,7 @@ class PercentageTest extends TestCase
         $requestMock->cookies = $parameterBagMock;
 
         $requestStackMock = $this->createMock(RequestStack::class);
-        $requestStackMock->method('getMasterRequest')->willReturn($requestMock);
+        $requestStackMock->method('getMainRequest')->willReturn($requestMock);
 
         $sut = new Percentage($requestStackMock);
         self::assertIsBool($sut->validate(['percentage' => 3]));

--- a/Toggle/Conditions/Device.php
+++ b/Toggle/Conditions/Device.php
@@ -18,11 +18,7 @@ class Device extends AbstractCondition implements ConditionInterface
      */
     public function __construct(RequestStack $request)
     {
-        if (method_exists($request, 'getMainRequest')) {
-            $this->request = $request->getMainRequest();
-        } else {
-            $this->request = $request->getMasterRequest();
-        }
+        $this->request = $request->getMainRequest();
     }
 
     /**

--- a/Toggle/Conditions/Device.php
+++ b/Toggle/Conditions/Device.php
@@ -18,7 +18,11 @@ class Device extends AbstractCondition implements ConditionInterface
      */
     public function __construct(RequestStack $request)
     {
-        $this->request = $request->getMasterRequest();
+        if (method_exists($request, 'getMainRequest')) {
+            $this->request = $request->getMainRequest();
+        } else {
+            $this->request = $request->getMasterRequest();
+        }
     }
 
     /**

--- a/Toggle/Conditions/Percentage.php
+++ b/Toggle/Conditions/Percentage.php
@@ -24,7 +24,11 @@ class Percentage extends AbstractCondition implements ConditionInterface
      */
     public function __construct(RequestStack $request)
     {
-        $this->request = $request->getMasterRequest();
+        if (method_exists($request, 'getMainRequest')) {
+            $this->request = $request->getMainRequest();
+        } else {
+            $this->request = $request->getMasterRequest();
+        }
     }
 
     /**

--- a/Toggle/Conditions/Percentage.php
+++ b/Toggle/Conditions/Percentage.php
@@ -24,11 +24,7 @@ class Percentage extends AbstractCondition implements ConditionInterface
      */
     public function __construct(RequestStack $request)
     {
-        if (method_exists($request, 'getMainRequest')) {
-            $this->request = $request->getMainRequest();
-        } else {
-            $this->request = $request->getMasterRequest();
-        }
+        $this->request = $request->getMainRequest();
     }
 
     /**

--- a/composer.json
+++ b/composer.json
@@ -12,14 +12,14 @@
         }
     ],
     "require": {
-        "php": ">=7.2",
-        "symfony/http-foundation": "~4.3|~5.0",
-        "symfony/http-kernel": "~4.3|~5.0",
-        "symfony/dependency-injection": "~4.3|~5.0",
-        "symfony/config": "~4.3|~5.0",
-        "symfony/console": "~4.3|~5.0",
-        "symfony/twig-bridge": "~4.3|~5.0",
-        "symfony/yaml": "~4.3|~5.0"
+        "php": ">=7.2.5",
+        "symfony/http-foundation": "~5.0",
+        "symfony/http-kernel": "~5.0",
+        "symfony/dependency-injection": "~5.0",
+        "symfony/config": "~5.0",
+        "symfony/console": "~5.0",
+        "symfony/twig-bridge": "~5.0",
+        "symfony/yaml": "~5.0"
     },
     "require-dev": {
         "twig/twig": "~2.0|~3.0",


### PR DESCRIPTION
Because the getMasterRequest gets called in the constructor of Device and Percentage it would trigger 2 deprecation notices in Symfony 5.3 and above. 

I suggest making a separate release for SF5 and later versions.