### PR TITLE
Fix use of deprecated getMasterRequest() method

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,7 +13,7 @@ jobs:
             fail-fast: false
             matrix:
                 php: [ '7.4', '8.0' ]
-                symfony: [ '^4.3', '^5.0' ]
+                symfony: [ '^4.4', '^5.4' ]
 
         name: PHP ${{ matrix.php }}
 

--- a/Tests/Toggle/Conditions/DeviceTest.php
+++ b/Tests/Toggle/Conditions/DeviceTest.php
@@ -12,15 +12,24 @@ use Symfony\Component\HttpFoundation\RequestStack;
 
 class DeviceTest extends TestCase
 {
-
     /**
      * @var RequestStack
      */
     private $requestStackMock;
 
+    /**
+     * @var string
+     */
+    private $mainRequestMethod = 'getMasterRequest';
+
     public function setUp() : void
     {
         $this->requestStackMock = $this->createMock(RequestStack::class);
+
+        if (method_exists($this->requestStackMock, 'getMainRequest'))
+        {
+            $this->mainRequestMethod = 'getMainRequest';
+        }
     }
 
     public function testItExtendsCorrectly()
@@ -46,7 +55,7 @@ class DeviceTest extends TestCase
         $requestMock = $this->createMock(Request::class);
         $requestMock->headers = $headerBagMock;
 
-        $this->requestStackMock->method('getMasterRequest')->willReturn($requestMock);
+        $this->requestStackMock->method($this->mainRequestMethod)->willReturn($requestMock);
 
         $sut = new Device($this->requestStackMock);
 
@@ -61,7 +70,7 @@ class DeviceTest extends TestCase
         $requestMock = $this->createMock(Request::class);
         $requestMock->headers = $headerBagMock;
 
-        $this->requestStackMock->method('getMasterRequest')->willReturn($requestMock);
+        $this->requestStackMock->method($this->mainRequestMethod)->willReturn($requestMock);
 
         $sut = new Device($this->requestStackMock);
 
@@ -82,7 +91,7 @@ class DeviceTest extends TestCase
         $requestMock = $this->createMock(Request::class);
         $requestMock->headers = $headerBagMock;
 
-        $this->requestStackMock->method('getMasterRequest')->willReturn($requestMock);
+        $this->requestStackMock->method($this->mainRequestMethod)->willReturn($requestMock);
 
         $sut = new Device($this->requestStackMock);
 

--- a/Tests/Toggle/Conditions/PercentageTest.php
+++ b/Tests/Toggle/Conditions/PercentageTest.php
@@ -13,6 +13,25 @@ use Symfony\Component\HttpFoundation\RequestStack;
 
 class PercentageTest extends TestCase
 {
+    /**
+     * @var RequestStack
+     */
+    private $requestStackMock;
+
+    /**
+     * @var string
+     */
+    private $mainRequestMethod = 'getMasterRequest';
+
+    public function setUp() : void
+    {
+        $this->requestStackMock = $this->createMock(RequestStack::class);
+
+        if (method_exists($this->requestStackMock, 'getMainRequest'))
+        {
+            $this->mainRequestMethod = 'getMainRequest';
+        }
+    }
 
     public function testItExtendsCorrectly()
     {
@@ -28,9 +47,7 @@ class PercentageTest extends TestCase
     {
         $this->expectException(Exception::class);
 
-        $requestStackMock = $this->createMock(RequestStack::class);
-
-        $sut = new Percentage($requestStackMock);
+        $sut = new Percentage($this->requestStackMock);
         $sut->validate([], 'nothing');
     }
 
@@ -43,10 +60,9 @@ class PercentageTest extends TestCase
         $requestMock = $this->createMock(Request::class);
         $requestMock->cookies = $parameterBagMock;
 
-        $requestStackMock = $this->createMock(RequestStack::class);
-        $requestStackMock->method('getMasterRequest')->willReturn($requestMock);
+        $this->requestStackMock->method($this->mainRequestMethod)->willReturn($requestMock);
 
-        $sut = new Percentage($requestStackMock);
+        $sut = new Percentage($this->requestStackMock);
         $this->assertTrue($sut->validate([
             'percentage' => 798,
         ]));
@@ -60,18 +76,15 @@ class PercentageTest extends TestCase
         $requestMock = $this->createMock(Request::class);
         $requestMock->cookies = $parameterBagMock;
 
-        $requestStackMock = $this->createMock(RequestStack::class);
-        $requestStackMock->method('getMasterRequest')->willReturn($requestMock);
+        $this->requestStackMock->method($this->mainRequestMethod)->willReturn($requestMock);
 
-        $sut = new Percentage($requestStackMock);
+        $sut = new Percentage($this->requestStackMock);
         self::assertIsBool($sut->validate(['percentage' => 3]));
     }
 
     public function testToString()
     {
-        $requestStackMock = $this->createMock(RequestStack::class);
-
-        $sut = new Percentage($requestStackMock);
+        $sut = new Percentage($this->requestStackMock);
 
         $this->assertSame('percentage', (string) $sut);
     }

--- a/Toggle/Conditions/Device.php
+++ b/Toggle/Conditions/Device.php
@@ -18,7 +18,11 @@ class Device extends AbstractCondition implements ConditionInterface
      */
     public function __construct(RequestStack $request)
     {
-        $this->request = $request->getMasterRequest();
+        if (method_exists($request, 'getMainRequest')) {
+            $this->request = $request->getMainRequest();
+        } else {
+            $this->request = $request->getMasterRequest();
+        }
     }
 
     /**

--- a/Toggle/Conditions/Percentage.php
+++ b/Toggle/Conditions/Percentage.php
@@ -24,7 +24,11 @@ class Percentage extends AbstractCondition implements ConditionInterface
      */
     public function __construct(RequestStack $request)
     {
-        $this->request = $request->getMasterRequest();
+        if (method_exists($request, 'getMainRequest')) {
+            $this->request = $request->getMainRequest();
+        } else {
+            $this->request = $request->getMasterRequest();
+        }
     }
 
     /**


### PR DESCRIPTION
Support both `getMasterRequest()` and `getMainRequest()` depending on which is available. The former for Symfony <5.3, the latter for >=5.3.

I have also bumped the Symfony versions in the workflow to use the Long Term Support versions, and updated the tests to account for the different method names.