### PR TITLE
Add symfony 6.1 support

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,45 +1,45 @@
 name: CI
 on:
-    pull_request: ~
-    push:
-        branches:
-            - master
-            - 5.x-dev
+  pull_request: ~
+  push:
+    branches:
+      - master
+      - 5.x-dev
 
 jobs:
-    ci:
-        runs-on: ubuntu-latest
-        strategy:
-            fail-fast: false
-            matrix:
-                php: [ '7.4', '8.0' ]
-                symfony: [ '^4.3', '^5.0' ]
+  ci:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        php: ['7.4', '8.0']
+        symfony: ['^4.3', '^5.0']
 
-        name: PHP ${{ matrix.php }}
+    name: PHP ${{ matrix.php }}
 
-        steps:
-            -   name: Checkout
-                uses: actions/checkout@v2
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
 
-            -   uses: shivammathur/setup-php@v2
-                with:
-                    php-version: ${{ matrix.php }}
+      - uses: shivammathur/setup-php@v2
+        with:
+          php-version: ${{ matrix.php }}
 
-            -   name: Load symfony version packages
-                run: |
-                    composer require --no-update symfony/http-foundation:${{ matrix.symfony }};
-                    composer require --no-update symfony/http-kernel:${{ matrix.symfony }};
-                    composer require --no-update symfony/dependency-injection:${{ matrix.symfony }};
-                    composer require --no-update symfony/config:${{ matrix.symfony }};
-                    composer require --no-update symfony/console:${{ matrix.symfony }};
-                    composer require --no-update symfony/twig-bridge:${{ matrix.symfony }};
+      - name: Load symfony version packages
+        run: |
+          composer require --no-update symfony/http-foundation:${{ matrix.symfony }};
+          composer require --no-update symfony/http-kernel:${{ matrix.symfony }};
+          composer require --no-update symfony/dependency-injection:${{ matrix.symfony }};
+          composer require --no-update symfony/config:${{ matrix.symfony }};
+          composer require --no-update symfony/console:${{ matrix.symfony }};
+          composer require --no-update symfony/twig-bridge:${{ matrix.symfony }};
 
-            -   uses: "ramsey/composer-install@v1"
-                with:
-                    dependency-versions: "lowest"
+      - uses: 'ramsey/composer-install@v1'
+        with:
+          dependency-versions: 'lowest'
 
-            -   name: Linting PHP
-                run: make lint-php
+      - name: Linting PHP
+        run: make lint-php
 
-            -   name: Unit Tests
-                run: ./vendor/bin/phpunit -v
+      - name: Unit Tests
+        run: ./vendor/bin/phpunit -v

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,6 +5,7 @@ on:
     branches:
       - master
       - 5.x-dev
+      - 6.x-dev
 
 jobs:
   ci:
@@ -12,8 +13,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php: ['8.0', '8.1']
-        symfony: ['^6.0']
+        php: ['8.1']
+        symfony: ['^6.0', '^6.1']
 
     name: PHP ${{ matrix.php }}
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,8 +12,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php: ['7.4', '8.0']
-        symfony: ['^4.3', '^5.0']
+        php: ['8.0', '8.1']
+        symfony: ['^6.0']
 
     name: PHP ${{ matrix.php }}
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -34,7 +34,7 @@ jobs:
           composer require --no-update symfony/console:${{ matrix.symfony }};
           composer require --no-update symfony/twig-bridge:${{ matrix.symfony }};
 
-      - uses: 'ramsey/composer-install@v1'
+      - uses: 'ramsey/composer-install@v2'
         with:
           dependency-versions: 'lowest'
 

--- a/Command/DebugFlagsCommand.php
+++ b/Command/DebugFlagsCommand.php
@@ -10,10 +10,14 @@ use Symfony\Component\Console\Output\OutputInterface;
 
 class DebugFlagsCommand extends Command
 {
-    /** @var Toggle */
+    /**
+     * @var Toggle
+     */
     private $toggle;
 
-    /** @var Toggle\ConditionBag */
+    /**
+     * @var Toggle\ConditionBag
+     */
     private $conditionBag;
 
     public function __construct(Toggle $toggle, Toggle\ConditionBag $conditionBag)
@@ -31,7 +35,7 @@ class DebugFlagsCommand extends Command
     }
 
 
-    protected function execute(InputInterface $input, OutputInterface $output)
+    protected function execute(InputInterface $input, OutputInterface $output): int
     {
         $output->writeln('');
         $output->writeln('<fg=cyan>Debugging Feature Flags</fg=cyan>');
@@ -59,6 +63,8 @@ class DebugFlagsCommand extends Command
         $this->renderFlagsTable($output);
 
         $output->writeln('');
+
+        return 0;
     }
 
     private function renderFlagsTable(OutputInterface $output)

--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -9,6 +9,9 @@ use Symfony\Component\Config\Definition\ConfigurationInterface;
 class Configuration implements ConfigurationInterface
 {
 
+    /**
+     * @return TreeBuilder
+     */
     public function getConfigTreeBuilder()
     {
         $treeBuilder = new TreeBuilder('d_zunke_feature_flags');

--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ configured directly in Symfony-Configs.
 **Use Versions ^2.0 if Symfony 3.0 Support is wanted!**
 **Use Versions ^4.0 if Symfony 4.2 Support is wanted!**
 **Use Versions ^5.0 if Symfony 4.3 or 5.x Support is wanted!**
+**Use Versions ^6.0 if Symfony 6.x Support is wanted!**
 
 ## Documentation
 
@@ -17,12 +18,12 @@ configured directly in Symfony-Configs.
 You can add the Bundle by running [Composer](http://getcomposer.org) on your shell or adding it directly to your composer.json
 
 ``` bash
-php composer.phar require dzunke/feature-flags-bundle:"^5.0"
+php composer.phar require dzunke/feature-flags-bundle:"^6.0"
 ```
 
 ``` json
 "require" :  {
-    "dzunke/feature-flags-bundle": "^5.0"
+    "dzunke/feature-flags-bundle": "^6.0"
 }
 ```
 The Namespace will be registered by autoloading with Composer but to use the integrated features for symfony you have to register the Bundle.

--- a/Tests/Toggle/Conditions/DeviceTest.php
+++ b/Tests/Toggle/Conditions/DeviceTest.php
@@ -46,7 +46,7 @@ class DeviceTest extends TestCase
         $requestMock = $this->createMock(Request::class);
         $requestMock->headers = $headerBagMock;
 
-        $this->requestStackMock->method('getMasterRequest')->willReturn($requestMock);
+        $this->requestStackMock->method('getMainRequest')->willReturn($requestMock);
 
         $sut = new Device($this->requestStackMock);
 
@@ -61,7 +61,7 @@ class DeviceTest extends TestCase
         $requestMock = $this->createMock(Request::class);
         $requestMock->headers = $headerBagMock;
 
-        $this->requestStackMock->method('getMasterRequest')->willReturn($requestMock);
+        $this->requestStackMock->method('getMainRequest')->willReturn($requestMock);
 
         $sut = new Device($this->requestStackMock);
 
@@ -82,7 +82,7 @@ class DeviceTest extends TestCase
         $requestMock = $this->createMock(Request::class);
         $requestMock->headers = $headerBagMock;
 
-        $this->requestStackMock->method('getMasterRequest')->willReturn($requestMock);
+        $this->requestStackMock->method('getMainRequest')->willReturn($requestMock);
 
         $sut = new Device($this->requestStackMock);
 

--- a/Tests/Toggle/Conditions/PercentageTest.php
+++ b/Tests/Toggle/Conditions/PercentageTest.php
@@ -44,7 +44,7 @@ class PercentageTest extends TestCase
         $requestMock->cookies = $parameterBagMock;
 
         $requestStackMock = $this->createMock(RequestStack::class);
-        $requestStackMock->method('getMasterRequest')->willReturn($requestMock);
+        $requestStackMock->method('getMainRequest')->willReturn($requestMock);
 
         $sut = new Percentage($requestStackMock);
         $this->assertTrue($sut->validate([
@@ -61,7 +61,7 @@ class PercentageTest extends TestCase
         $requestMock->cookies = $parameterBagMock;
 
         $requestStackMock = $this->createMock(RequestStack::class);
-        $requestStackMock->method('getMasterRequest')->willReturn($requestMock);
+        $requestStackMock->method('getMainRequest')->willReturn($requestMock);
 
         $sut = new Percentage($requestStackMock);
         self::assertIsBool($sut->validate(['percentage' => 3]));

--- a/Toggle/ConditionBag.php
+++ b/Toggle/ConditionBag.php
@@ -15,7 +15,7 @@ class ConditionBag implements \IteratorAggregate, \Countable
     /**
      * @return \ArrayIterator
      */
-    public function getIterator()
+    public function getIterator(): \Traversable
     {
         return new \ArrayIterator($this->conditions);
     }
@@ -23,7 +23,7 @@ class ConditionBag implements \IteratorAggregate, \Countable
     /**
      * @return int
      */
-    public function count()
+    public function count(): int
     {
         return count($this->conditions);
     }

--- a/Toggle/Conditions/Device.php
+++ b/Toggle/Conditions/Device.php
@@ -18,7 +18,7 @@ class Device extends AbstractCondition implements ConditionInterface
      */
     public function __construct(RequestStack $request)
     {
-        $this->request = $request->getMasterRequest();
+        $this->request = $request->getMainRequest();
     }
 
     /**

--- a/Toggle/Conditions/Percentage.php
+++ b/Toggle/Conditions/Percentage.php
@@ -24,7 +24,7 @@ class Percentage extends AbstractCondition implements ConditionInterface
      */
     public function __construct(RequestStack $request)
     {
-        $this->request = $request->getMasterRequest();
+        $this->request = $request->getMainRequest();
     }
 
     /**

--- a/Twig/FeatureExtension.php
+++ b/Twig/FeatureExtension.php
@@ -22,7 +22,10 @@ class FeatureExtension extends AbstractExtension
         $this->toggle = $toggle;
     }
 
-    public function getFunctions()
+    /**
+     * @return TwigFunction[]
+     */
+    public function getFunctions(): array
     {
         return [
             new TwigFunction('has_feature', [$this, 'checkFeature'], ['is_safe' => ['html']]),
@@ -30,8 +33,8 @@ class FeatureExtension extends AbstractExtension
     }
 
     /**
-     * @param string $name
-     * @param array  $arguments
+     * @param  string $name
+     * @param  array  $arguments
      * @return bool
      */
     public function checkFeature($name, $arguments = null)

--- a/composer.json
+++ b/composer.json
@@ -12,18 +12,18 @@
         }
     ],
     "require": {
-        "php": ">=7.2",
-        "symfony/http-foundation": "~4.3|~5.0",
-        "symfony/http-kernel": "~4.3|~5.0",
-        "symfony/dependency-injection": "~4.3|~5.0",
-        "symfony/config": "~4.3|~5.0",
-        "symfony/console": "~4.3|~5.0",
-        "symfony/twig-bridge": "~4.3|~5.0",
-        "symfony/yaml": "~4.3|~5.0"
+        "php": ">=8.0.2",
+        "symfony/http-foundation": "~6.0",
+        "symfony/http-kernel": "~6.0",
+        "symfony/dependency-injection": "~6.0",
+        "symfony/config": "~6.0",
+        "symfony/console": "~6.0",
+        "symfony/twig-bridge": "~6.0",
+        "symfony/yaml": "~6.0"
     },
     "require-dev": {
         "twig/twig": "~2.0|~3.0",
-        "phpunit/phpunit": "~8"
+        "phpunit/phpunit": "~9"
     },
     "autoload": {
         "psr-0": { "DZunke\\FeatureFlagsBundle": "" }

--- a/composer.json
+++ b/composer.json
@@ -12,14 +12,14 @@
         }
     ],
     "require": {
-        "php": ">=8.0.2",
-        "symfony/http-foundation": "~6.0",
-        "symfony/http-kernel": "~6.0",
-        "symfony/dependency-injection": "~6.0",
-        "symfony/config": "~6.0",
-        "symfony/console": "~6.0",
-        "symfony/twig-bridge": "~6.0",
-        "symfony/yaml": "~6.0"
+        "php": ">=8.1",
+        "symfony/http-foundation": "~6.0|~6.1",
+        "symfony/http-kernel": "~6.0|~6.1",
+        "symfony/dependency-injection": "~6.0|~6.1",
+        "symfony/config": "~6.0|~6.1",
+        "symfony/console": "~6.0|~6.1",
+        "symfony/twig-bridge": "~6.0|~6.1",
+        "symfony/yaml": "~6.0|~6.1"
     },
     "require-dev": {
         "twig/twig": "~2.0|~3.0",

--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
     },
     "require-dev": {
         "twig/twig": "~2.0|~3.0",
-        "phpunit/phpunit": "~9"
+        "phpunit/phpunit": "~9.4"
     },
     "autoload": {
         "psr-0": { "DZunke\\FeatureFlagsBundle": "" }


### PR DESCRIPTION
The Symfony 6.1 requires PHP 8.1+, because of that i create another pull request. Probably will require a different version.

This PR depends of https://github.com/DZunke/FeatureFlagsBundle/pull/36